### PR TITLE
remove amount variable

### DIFF
--- a/contracts/FundForwarder.sol
+++ b/contracts/FundForwarder.sol
@@ -63,11 +63,9 @@ contract FundForwarder is Escapable {
     ///  `msg.sender` is rewarded with Campaign tokens; this contract may have a
     ///  high gasLimit requirement dependent on beneficiary
     function () payable {
-        uint amount;
-        amount = msg.value;
         // Send the ETH to the beneficiary so that they receive Campaign tokens
-        require (beneficiary.proxyPayment.value(amount)(msg.sender));
-        FundsSent(msg.sender, amount);
+        require (beneficiary.proxyPayment.value(msg.value)(msg.sender));
+        FundsSent(msg.sender, msg.value);
     }
     event FundsSent(address indexed sender, uint amount);
 }


### PR DESCRIPTION
Resolves #6 

Semantically I like overly verbose code and using variables as often as possible; it would be worth seeing if there's a gas difference as to me that's the main reason to remove the amount variable. Otherwise, it's mostly semantics but I prioritize gas efficiency over semantic clarity and since I'm not doing the tests now the change was made.